### PR TITLE
Fix for WPSD clients using M17 protocol

### DIFF
--- a/reflector/DVHeaderPacket.cpp
+++ b/reflector/DVHeaderPacket.cpp
@@ -150,7 +150,17 @@ CDvHeaderPacket::CDvHeaderPacket(const CM17Packet &m17) : CPacket(m17)
 	m_uiCrc = 0;
 	m_csUR = CCallsign("CQCQCQ");
 	m_csMY = m17.GetSourceCallsign();
-	m_csRPT1 = m_csRPT2 = m17.GetDestCallsign();
+	auto str = m17.GetDestCallsign().GetCS();
+	if (0 == str.compare(0, 4, "URF-"))
+	{
+		// take care of WPSD M17Host file format
+		str.erase(str.begin()+3);
+		m_csRPT1 = m_csRPT2 = CCallsign(str);
+	}
+	else
+	{
+		m_csRPT1 = m_csRPT2 = m17.GetDestCallsign();
+	}
 	m_csRPT1.SetCSModule('G');
 }
 

--- a/reflector/Main.cpp
+++ b/reflector/Main.cpp
@@ -28,7 +28,7 @@ SJsonKeys   g_Keys;
 CReflector  g_Reflector;
 CGateKeeper g_GateKeeper;
 CConfigure  g_Configure;
-CVersion    g_Version(3,1,2); // The major byte should only change if the interlink packet changes!
+CVersion    g_Version(3,1,3); // The major byte should only change if the interlink packet changes!
 CLookupDmr  g_LDid;
 CLookupNxdn g_LNid;
 CLookupYsf  g_LYtr;


### PR DESCRIPTION
WPSD adds a dash to the URF callsign in its host file. It then uses that name to generate the destination callsign in its M17 voice stream packets.

This simple fix will remove the dash.