### PR TITLE
fixes for AutolinkModule parameters and radmin

### DIFF
--- a/config/urfd.ini
+++ b/config/urfd.ini
@@ -37,7 +37,7 @@ IPv4Binding = 0.0.0.0
 # Modules = ABCDEFGHIJKLMNOPQRSTUVWXYZ
 Modules = ADMSZ
 # Create Descriptions as needed...
-DescriptionA = Transcoded
+DescriptionA = All Modes
 DescriptionD = DMR Chat
 DescriptionM = M17 Chat
 DescriptionS = DStar Chat
@@ -91,7 +91,7 @@ Port = 10017
 
 [USRP]
 Enable = false
-Callsign = ALLSTAR  # set to NONE if you don't want to create this client
+Callsign = ALLSTAR
 IPAddress = 1.2.3.4 # the IP address of the USRP client (the Allstar node)
 RxPort = 34000
 TxPort = 32000

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -86,7 +86,7 @@ if ($CallingHome['Active']) {
     <meta name="robots" content="<?php echo $PageOptions['MetaAuthor']; ?>"/>
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <title><?php echo str_replace("XLX", "URF", $Reflector->GetReflectorName()); ?>Universal Reflector</title>
+    <title><?php echo str_replace("XLX", "URF", $Reflector->GetReflectorName()); ?> Universal Reflector</title>
     <link rel="icon" href="./favicon.ico" type="image/vnd.microsoft.icon">
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -152,7 +152,7 @@ if ($CallingHome['Active']) {
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <span class="navbar-brand"><?php echo $Reflector->GetReflectorName(); ?> Multiprotocol Reflector</span>
+            <span class="navbar-brand"><?php echo str_replace("XLX", "URF", $Reflector->GetReflectorName()); ?> Universal Reflector</span>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">

--- a/radmin
+++ b/radmin
@@ -35,7 +35,7 @@ UninstallReflector () {
 }
 
 InstallReflector () {
-	if [ "$tcaddress" != none ]; then
+	if [ "$tcport" != 0 ]; then
 		pushd ../tcd
 		sudo make install || read -p "<Enter> to continue: " ans
 		popd
@@ -63,22 +63,19 @@ InstallReflector () {
 urfserv='/etc/systemd/system/urfd.service'
 tcdserv='/etc/systemd/system/tcd.service'
 
-# default values, we only need a few
-tcaddress='none'
-
 if [[ $# -eq 1 ]]; then
 	if [ -e $1 ]; then
 		echo $1 found
-		callsign=$(awk '$1 == "Callsign"{print $3}' $1)
-		tcaddress=$(awk '$1 == "Transcoder"{print $3}' $1)
+		callsign=$(awk '$1 == "Callsign"{print $3; exit}' $1)
+		tcport=$(awk '$1 == "Port"{print $3; exit}' $1)
 	else
 		echo "$1 not found"
 		exit 1
 	fi
 else
 	if [[ -e reflector/urfd.ini ]]; then
-		callsign=$(awk '$1 == "Callsign"{print $3}' reflector/urfd.ini)
-		tcaddress=$(awk '$1 == "Transcoder"{print $3}' reflector/urfd.ini)
+		callsign=$(awk '$1 == "Callsign"{print $3; exit}' reflector/urfd.ini)
+		tcport=$(awk '$1 == "Port"{print $3; exit}' reflector/urfd.ini)
 	else
 		echo "ERROR: could not find reflector/urfd.ini! You'll have to specify it."
 		echo "Usage: ./radmin PATH-TO-INI-FILE"
@@ -97,7 +94,7 @@ do
 		ps -aux | grep -e urfd -e tcd | grep -v grep | grep -v radmin
 	fi
 	echo
-	echo "        Reflector Administration, Version #230308"
+	echo "        Reflector Administration, Version #240808"
 	echo
 	git status | head -1
 	echo
@@ -116,13 +113,17 @@ do
 	else
 		if [[ "$callsign" == URF* ]]; then
 			if [ -e reflector/urfd ]; then
-				if [[ "$tcaddress" == none ]]; then
+				if [[ "$tcport" == 0 ]]; then
 					echo "is : Install URF reflector without transcoder"
 				else
 					if [ -e ../tcd/tcd ]; then
 						echo "is : Install URF reflector and transcoder"
+					else
+						echo "HELP! Transcoder port is set, but tcd executable not found!"
 					fi
 				fi
+			else
+				echo "HELP! urfd executable not found!"
 			fi
 		fi
 	fi

--- a/reflector/Client.cpp
+++ b/reflector/Client.cpp
@@ -85,11 +85,11 @@ void CClient::WriteXml(std::ofstream &xmlFile)
 	xmlFile << "\t<LinkedModule>" << m_ReflectorModule << "</LinkedModule>" << std::endl;
 	xmlFile << "\t<Protocol>" << GetProtocolName() << "</Protocol>" << std::endl;
 	char mbstr[100];
-	if (std::strftime(mbstr, sizeof(mbstr), "%A %c", std::localtime(&m_ConnectTime)))
+	if (std::strftime(mbstr, sizeof(mbstr), "%FT%TZ", std::gmtime(&m_ConnectTime)))
 	{
 		xmlFile << "\t<ConnectTime>" << mbstr << "</ConnectTime>" << std::endl;
 	}
-	if (std::strftime(mbstr, sizeof(mbstr), "%A %c", std::localtime(&m_LastHeardTime)))
+	if (std::strftime(mbstr, sizeof(mbstr), "%FT%TZ", std::gmtime(&m_LastHeardTime)))
 	{
 		xmlFile << "\t<LastHeardTime>" << mbstr << "</LastHeardTime>" << std::endl;
 	}

--- a/reflector/Configure.cpp
+++ b/reflector/Configure.cpp
@@ -819,21 +819,19 @@ bool CConfigure::isDefined(ErrorLevel level, const std::string &section, const s
 	return false;
 }
 
-void CConfigure::checkAutoLink(const std::string &section, const std::string &pname, const std::string &key, bool &rval)
+void CConfigure::checkAutoLink(const std::string &section, const std::string &pname, const std::string &key, bool &rval) const
 {
-	if (data.contains(key))
+	const auto autolinkModule = GetAutolinkModule(key);
+	if (' ' != autolinkModule)
 	{
 		auto ismods = data.contains(g_Keys.modules.modules);
 		const auto mods(ismods ? data[g_Keys.modules.modules].get<std::string>() : "");
-		const auto c = data[key].get<std::string>().at(0);
-		if (std::string::npos == mods.find(c))
+		if (std::string::npos == mods.find(autolinkModule))
 		{
-			std::cerr << "ERROR: [" << section << ']' << pname << " module '" << c << "' not a configured module" << std::endl;
+			std::cerr << "ERROR: [" << section << ']' << pname << " module '" << autolinkModule << "' not a configured module" << std::endl;
 			rval = true;
 		}
 	}
-	else
-		data[key] = nullptr;
 }
 
 std::string CConfigure::getDataRefreshType(ERefreshType type) const
@@ -865,7 +863,7 @@ void CConfigure::badParam(const std::string &key) const
 bool CConfigure::checkModules(std::string &m) const
 {
 	bool rval = false; // return true on error
-	for(unsigned i=0; i<m.size(); i++)
+	for (unsigned i=0; i<m.size(); i++)
 		if (islower(m[i]))
 			m[i] = toupper(m[i]);
 
@@ -988,7 +986,7 @@ bool CConfigure::GetBoolean(const std::string &key) const
 
 char CConfigure::GetAutolinkModule(const std::string &key) const
 {
-	char c = 0;
+	char c = ' ';
 	if (data.contains(key))
 	{
 		if (data[key].is_string())

--- a/reflector/Configure.h
+++ b/reflector/Configure.h
@@ -57,5 +57,5 @@ private:
 	void checkFile(const std::string &section, const std::string &key, const std::string &filepath) const;
 	void setAutolink(const std::string &section, const std::string &key, const std::string &value);
 	bool isDefined(ErrorLevel level, const std::string &section, const std::string &pname, const std::string &key, bool &rval);
-	void checkAutoLink(const std::string &section, const std::string &pname, const std::string &key, bool &rval);
+	void checkAutoLink(const std::string &section, const std::string &pname, const std::string &key, bool &rval) const;
 };

--- a/reflector/CurlGet.cpp
+++ b/reflector/CurlGet.cpp
@@ -62,7 +62,7 @@ CURLcode CCurlGet::GetURL(const std::string &url, std::stringstream &ss, long ti
 	}
 	if (code != CURLE_OK)
 	{
-		std::cout << "ERROR: was not able retrieve data at '" << url << "'\nCurl returned: " << code << std::endl;
+		std::cout << "WARNING: was not able retrieve data at '" << url << "'\nCurl returned: " << code << std::endl;
 	}
 	return code;
 }

--- a/reflector/Main.cpp
+++ b/reflector/Main.cpp
@@ -28,7 +28,7 @@ SJsonKeys   g_Keys;
 CReflector  g_Reflector;
 CGateKeeper g_GateKeeper;
 CConfigure  g_Configure;
-CVersion    g_Version(3,1,3); // The major byte should only change if the interlink packet changes!
+CVersion    g_Version(3,1,4); // The major byte should only change if the interlink packet changes!
 CLookupDmr  g_LDid;
 CLookupNxdn g_LNid;
 CLookupYsf  g_LYtr;

--- a/reflector/NXDNProtocol.cpp
+++ b/reflector/NXDNProtocol.cpp
@@ -133,7 +133,7 @@ void CNXDNProtocol::Task(void)
 					auto newclient = std::make_shared<CNXDNClient>(Callsign, Ip);
 
 					// aautolink, if enabled
-					if (m_AutolinkModule)
+					if (' ' != m_AutolinkModule)
 						newclient->SetReflectorModule(m_AutolinkModule);
 
 					// and append

--- a/reflector/P25Protocol.cpp
+++ b/reflector/P25Protocol.cpp
@@ -122,7 +122,7 @@ void CP25Protocol::Task(void)
 					auto newclient = std::make_shared<CP25Client>(Callsign, Ip);
 
 					// aautolink, if enabled
-					if (m_AutolinkModule)
+					if (' ' != m_AutolinkModule)
 						newclient->SetReflectorModule(m_AutolinkModule);
 
 					// and append

--- a/reflector/Peer.cpp
+++ b/reflector/Peer.cpp
@@ -114,11 +114,11 @@ void CPeer::WriteXml(std::ofstream &xmlFile)
 	xmlFile << "\t<LinkedModule>" << m_ReflectorModules << "</LinkedModule>" << std::endl;
 	xmlFile << "\t<Protocol>" << GetProtocolName() << "</Protocol>" << std::endl;
 	char mbstr[100];
-	if (std::strftime(mbstr, sizeof(mbstr), "%A %c", std::localtime(&m_ConnectTime)))
+	if (std::strftime(mbstr, sizeof(mbstr), "%FT%TZ", std::gmtime(&m_ConnectTime)))
 	{
 		xmlFile << "\t<ConnectTime>" << mbstr << "</ConnectTime>" << std::endl;
 	}
-	if (std::strftime(mbstr, sizeof(mbstr), "%A %c", std::localtime(&m_LastHeardTime)))
+	if (std::strftime(mbstr, sizeof(mbstr), "%FT%TZ", std::gmtime(&m_LastHeardTime)))
 	{
 		xmlFile << "\t<LastHeardTime>" << mbstr << "</LastHeardTime>" << std::endl;
 	}

--- a/reflector/Protocols.cpp
+++ b/reflector/Protocols.cpp
@@ -94,7 +94,7 @@ bool CProtocols::Init(void)
 		if (g_Configure.GetBoolean(g_Keys.usrp.enable))
 		{
 			m_Protocols.emplace_back(std::unique_ptr<CUSRPProtocol>(new CUSRPProtocol));
-			if (! m_Protocols.back()->Initialize("USRP", EProtocol::usrp, uint16_t(g_Configure.GetUnsigned(g_Keys.usrp.rxport)), USRP_IPV4, 	USRP_IPV6))
+			if (! m_Protocols.back()->Initialize("USRP", EProtocol::usrp, uint16_t(g_Configure.GetUnsigned(g_Keys.usrp.rxport)), USRP_IPV4, USRP_IPV6))
 				return false;
 		}
 

--- a/reflector/Reflector.cpp
+++ b/reflector/Reflector.cpp
@@ -532,9 +532,9 @@ void CReflector::PutDHTConfig()
 	std::ostringstream ss;
 	ss << g_Version;
 	cfg.version.assign(ss.str());
-	cfg.almod[toUType(EUrfdAlMod::nxdn)]   = g_Configure.GetString(g_Keys.nxdn.autolinkmod).at(0);
-	cfg.almod[toUType(EUrfdAlMod::p25)]    = g_Configure.GetString(g_Keys.p25.autolinkmod).at(0);
-	cfg.almod[toUType(EUrfdAlMod::ysf)]    = g_Configure.GetString(g_Keys.ysf.autolinkmod).at(0);
+	cfg.almod[toUType(EUrfdAlMod::nxdn)]   = g_Configure.GetAutolinkModule(g_Keys.nxdn.autolinkmod);
+	cfg.almod[toUType(EUrfdAlMod::p25)]    = g_Configure.GetAutolinkModule(g_Keys.p25.autolinkmod);
+	cfg.almod[toUType(EUrfdAlMod::ysf)]    = g_Configure.GetAutolinkModule(g_Keys.ysf.autolinkmod);
 	cfg.ysffreq[toUType(EUrfdTxRx::rx)]    = g_Configure.GetUnsigned(g_Keys.ysf.defaultrxfreq);
 	cfg.ysffreq[toUType(EUrfdTxRx::tx)]    = g_Configure.GetUnsigned(g_Keys.ysf.defaulttxfreq);
 	cfg.refid[toUType(EUrfdRefId::nxdn)]   = g_Configure.GetUnsigned(g_Keys.nxdn.reflectorid);

--- a/reflector/TCSocket.h
+++ b/reflector/TCSocket.h
@@ -37,7 +37,6 @@ public:
 	void Close(); // close all open sockets
 	void Close(char module); // close a specific module
 	void Close(int fd); // close a specific file descriptor
-	bool receive(int fd, STCPacket *packet);
 
 	// All bool functions, except Server Receive, return true if there was an error
 	bool Send(const STCPacket *packet);
@@ -46,6 +45,7 @@ public:
 	char GetMod(int fd) const;
 
 protected:
+	bool receive(int fd, STCPacket *packet);
 	std::vector<struct pollfd> m_Pfd;
 	std::string m_Modules;
 };

--- a/reflector/User.cpp
+++ b/reflector/User.cpp
@@ -70,7 +70,7 @@ void CUser::WriteXml(std::ofstream &xmlFile)
 	xmlFile << "\t<Via peer>" << m_Xlx << "</Via peer>" << std::endl;
 
 	char mbstr[100];
-	if (std::strftime(mbstr, sizeof(mbstr), "%A %c", std::localtime(&m_LastHeardTime)))
+	if (std::strftime(mbstr, sizeof(mbstr), "%FT%TZ", std::gmtime(&m_LastHeardTime)))
 	{
 		xmlFile << "\t<LastHeardTime>" << mbstr << "</LastHeardTime>" << std::endl;
 	}

--- a/reflector/YSFProtocol.cpp
+++ b/reflector/YSFProtocol.cpp
@@ -164,7 +164,7 @@ void CYsfProtocol::Task(void)
 					auto newclient = std::make_shared<CYsfClient>(Callsign, Ip);
 
 					// aautolink, if enabled
-					if (m_AutolinkModule)
+					if (' ' != m_AutolinkModule)
 						newclient->SetReflectorModule(m_AutolinkModule);
 
 					// and append


### PR DESCRIPTION
This fixes a crash when no AutolinkModule is specified for NXDN, YSF and P25.

Also fixes awk problems in the radmin script with the new ini file formats introduced with remote transcoding changes.