### PR TITLE
feat(ysf): implement module selection by DGID

### DIFF
--- a/reflector/Configure.cpp
+++ b/reflector/Configure.cpp
@@ -83,6 +83,7 @@
 #define JTRANSCODER              "Transcoder"
 #define JTXPORT                  "TxPort"
 #define JURF                     "URF"
+#define JENABLEDGID              "EnableDGID"
 #define JURL                     "URL"
 #define JUSRP                    "USRP"
 #define JWHITELISTPATH           "WhitelistPath"
@@ -428,6 +429,8 @@ bool CConfigure::ReadData(const std::string &path)
 					data[g_Keys.ysf.port] = getUnsigned(value, "YSF Port", 1024, 65535, 42000);
 				else if (0 == key.compare(JAUTOLINKMODULE))
 					setAutolink(JYSF, g_Keys.ysf.autolinkmod, value);
+				else if (0 == key.compare(JENABLEDGID))
+					data[g_Keys.ysf.enabledgid] = IS_TRUE(value[0]);
 				else if (0 == key.compare(JDEFAULTTXFREQ))
 					data[g_Keys.ysf.defaulttxfreq] = getUnsigned(value, "YSF DefaultTxFreq", 40000000, 2600000000, 439000000);
 				else if (0 == key.compare(JDEFAULTRXFREQ))
@@ -753,6 +756,7 @@ bool CConfigure::ReadData(const std::string &path)
 
 	// YSF
 	isDefined(ErrorLevel::fatal, JYSF, JPORT, g_Keys.ysf.port, rval);
+	isDefined(ErrorLevel::mild, JYSF, JENABLEDGID, g_Keys.ysf.enabledgid, rval);
 	checkAutoLink(JYSF, JAUTOLINKMODULE, g_Keys.ysf.autolinkmod, rval);
 	isDefined(ErrorLevel::fatal, JYSF, JDEFAULTRXFREQ, g_Keys.ysf.defaultrxfreq, rval);
 	isDefined(ErrorLevel::fatal, JYSF, JDEFAULTTXFREQ, g_Keys.ysf.defaulttxfreq, rval);

--- a/reflector/JsonKeys.h
+++ b/reflector/JsonKeys.h
@@ -59,9 +59,9 @@ struct SJsonKeys {
 	p25 { "P25Port",  "P25AutolinkMod",   "P25ReflectorID" },
 	nxdn { "NXDNPort", "NXDNAutolinkMod", "NXDNReflectorID" };
 
-	struct YSF { const std::string port, autolinkmod, defaulttxfreq, defaultrxfreq;
+	struct YSF { const std::string port, autolinkmod, enabledgid, defaulttxfreq, defaultrxfreq;
 		struct YSLREG { const std::string id, name, description; } ysfreflectordb; }
-	ysf { "YSFPort", "YSFAutoLinkMod", "YSFDefaultTxFreq", "YSFDefaultRxFreq",
+	ysf { "YSFPort", "YSFAutoLinkMod", "YSFEnableDGID", "YSFDefaultTxFreq", "YSFDefaultRxFreq",
 		{ "ysfrefdbid", "ysfrefdbname", "ysfrefdbdesc" } };
 
 	struct DB { const std::string url, mode, refreshmin, filepath; }

--- a/reflector/YSFProtocol.h
+++ b/reflector/YSFProtocol.h
@@ -79,7 +79,7 @@ protected:
 	void HandleKeepalives(void);
 
 	// stream helpers
-	void OnDvHeaderPacketIn(std::unique_ptr<CDvHeaderPacket> &, const CIp &);
+	void OnDvHeaderPacketIn(std::unique_ptr<CDvHeaderPacket> &, const CIp &, uint8_t = 0);
 
 	// DV packet decoding helpers
 	bool IsValidConnectPacket(const CBuffer &, CCallsign *);
@@ -132,6 +132,7 @@ protected:
 
 	// config data
 	char m_AutolinkModule;
+	bool m_EnableDGID;
 	unsigned m_RegistrationId;
 	std::string m_RegistrationName, m_RegistrationDesc;
 };


### PR DESCRIPTION
# Walkthrough - YSF Module Selection by DGID

Resolves #14

I have implemented the DGID-based module selection for YSF clients. This feature allows users to switch reflector modules by changing the DGID on their radio.

## Changes Made

### Configuration

- **JsonKeys.h**: Added `enabledgid` to the `YSF` configuration structure.
- **Configure.cpp**: Added logic to parse `EnableDGID` from the `[YSF]` section of `urfd.ini`. It defaults to `false` if not specified.

### YSF Protocol

- **YSFProtocol.h**: Added `m_EnableDGID` member and updated `OnDvHeaderPacketIn` to accept a `dgid` parameter.
- **YSFProtocol.cpp**:
  - Initialized `m_EnableDGID` during protocol initialization.
  - Updated `Task()` to extract the DGID (SQL byte) from the FICH field and pass it to `OnDvHeaderPacketIn`.
  - Implemented the module switching logic: when enabled, DGID 10-35 maps to modules A-Z. The switch is "sticky" for the duration of the session.

## Verification Results

### Build Verification

I verified that the code compiles successfully by running a build inside the provided Docker container.

```bash
# Compilation successfully completed inside docker container 'urfd-runner'
make -C reflector
```

> [!NOTE]
> I had to temporarily disable DHT and `-Werror` for the build to succeed in the test environment because some dependencies (like `opendht`) and compiler flags behave differently on Mac vs. the target Linux container. These temporary changes were reverted after verification.

## How to Use

1. Add `EnableDGID=true` to your `[YSF]` section in `urfd.ini`.
2. Restart `urfd`.
3. Transmit with DGID=10 to switch to Module A, DGID=11 for Module B, etc.
4. Once switched, you can change your radio back to DGID=0 and remain on that module.

---
render_diffs(file:///Users/dbehnke/development/urfd/reflector/JsonKeys.h)
render_diffs(file:///Users/dbehnke/development/urfd/reflector/Configure.cpp)
render_diffs(file:///Users/dbehnke/development/urfd/reflector/YSFProtocol.h)
render_diffs(file:///Users/dbehnke/development/urfd/reflector/YSFProtocol.cpp)
