### PR TITLE
fix(tc): prevent runaway CPU and blocking in transcoder handling

### DIFF
--- a/reflector/TCSocket.cpp
+++ b/reflector/TCSocket.cpp
@@ -185,6 +185,7 @@ bool CTCServer::Receive(char module, STCPacket *packet, int ms)
 	auto pfds = &m_Pfd[pos];
 	if (pfds->fd < 0)
 	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 		return rv;
 	}
 
@@ -287,7 +288,7 @@ bool CTCServer::Accept()
 			wmod.append(1, c);
 	}
 
-	std::cout << "Waiting at " << m_Ip << " for transcoder connection";
+	std::cout << "Checking " << m_Ip << " for transcoder connection";
 	if (wmod.size() > 1)
 	{
 		std::cout << "s for modules ";
@@ -298,8 +299,23 @@ bool CTCServer::Accept()
 	}
 	std::cout << wmod << "..." << std::endl;
 
+	struct pollfd pfd;
+	pfd.fd = fd;
+	pfd.events = POLLIN;
+
 	while (AnyAreClosed())
 	{
+		auto p = poll(&pfd, 1, 100); // 100ms timeout
+		if (p < 0)
+		{
+			perror("Accept poll");
+			close(fd);
+			Close();
+			return true;
+		}
+		if (0 == p)
+			break; // No more pending connections for now
+
 		if (acceptone(fd))
 		{
 			close(fd);


### PR DESCRIPTION
# Walkthrough - Runaway CPU and Blocking Fixes

Resolves #15

I have implemented fixes to address high CPU usage and hanging behavior related to transcoder (`tcd`) connections.

## Changes Made

### Transcoder Socket Handling (`TCSocket.cpp`)

- **Fixed Runaway CPU**: Added a sleep delay in `CTCServer::Receive` that is triggered when a transcoder module is not connected. This prevents `CCodecStream` threads from spinning in a tight high-frequency loop when `tcd` is unreachable.
- **Fixed Blocking Behavior**: Modified `CTCServer::Accept` to be non-blocking. It now uses `poll` with a 100ms timeout on the listening socket. If no connections are pending, it returns immediately instead of waiting indefinitely. This ensures the main `MaintenanceThread` can continue updating the dashboard even if some transcoder modules are disconnected.

## Verification Results

### Build Verification

I verified that the code compiles successfully by running a build inside the `urfd-runner` Docker container.

```bash
# Compilation successfully completed inside docker container
docker exec urfd-runner make -C reflector
```

> [!NOTE]
> During verification, I temporarily disabled DHT and strict `-Werror` flags to accommodate the testing environment. These were fully reverted after the build was confirmed.

## How to Verify

1. Start `urfd` with transcoder modules configured but without `tcd` running.
2. Verify that CPU usage remains low (no runaway `urfd` process).
3. Verify that the dashboard (XML/JSON files) continues to update.
4. Start `tcd` and verify that `urfd` gracefully picks up the connections within a few seconds (next `MaintenanceThread` cycle).

---
render_diffs(file:///Users/dbehnke/development/urfd/reflector/TCSocket.cpp)
