### PR TITLE
Fix: hardening CConfigure::GetBoolean against missing keys

### DIFF
--- a/reflector/Configure.cpp
+++ b/reflector/Configure.cpp
@@ -978,8 +978,8 @@ unsigned CConfigure::GetUnsigned(const std::string &key) const
 
 bool CConfigure::GetBoolean(const std::string &key) const
 {
-	if (data[key].is_boolean())
-		return data[key];
+	if (data.contains(key) && data[key].is_boolean())
+		return data[key].get<bool>();
 	else
 		return false;
 }


### PR DESCRIPTION
This PR fixes a fatal assertion (crash) in the reflector that occurs when `g_Configure.GetBoolean()` is called on a key that is missing from the configuration object (e.g., when an optional protocol section is omitted from the .ini file).

#### Technical Details

- The `nlohmann/json` `const` `operator[]` asserts that the key exists.
- Updated `GetBoolean` to use `.contains()` before access.
- Returns `false` gracefully if the key is missing or not a boolean type.

This improvement was discovered during integration testing of multiple feature PRs in a minimal staging environment.
