### PR TITLE
Add EnableDGID option to urfd.ini configuration

### DIFF
--- a/config/urfd.ini
+++ b/config/urfd.ini
@@ -103,6 +103,7 @@ Port = 42000
 AutoLinkModule = A  # comment out if you want to disable AL
 DefaultTxFreq = 446500000
 DefaultRxFreq = 446500000
+EnableDGID = true  # if true, allows YSF users to change modules using DGIDs. if false, DGIDs have no effect.
 # if you've registered your reflector at register.ysfreflector.de:
 RegistrationID = 12345
 RegistrationName = US URF???


### PR DESCRIPTION
Added EnableDGID option and comment to [YSF] section of urfd.ini to go along with update to reflector from a few days ago.

I've updated two instances of URFD with this and both are working.